### PR TITLE
Fix UTF-8 BOM stripping

### DIFF
--- a/FeedParser.hs
+++ b/FeedParser.hs
@@ -81,7 +81,7 @@ parse fp name =
                            (Feed {channeltitle = title, items = feeditems})
        where getContent (Document _ _ e _) = CElem e noPos
 
-unifrob ('\xfeff':x) = x -- Strip off unicode BOM
+unifrob ('\xef':'\xbb':'\xbf':x) = x -- Strip off UTF-8 BOM
 unifrob x = x
 
 unesc = xmlUnEscape stdXmlEscaper


### PR DESCRIPTION
Revert commit d3a7eb94.

After commit bd08d07c, openBinaryFile is used to read file contents
rather than readFile.  When using openBinaryFile, the UTF-8 BOM, if
present, will appear as 3 separate characters.  Strip these characters.

Note:  It seems to me that HaXml should be responsible for stripping the
BOM after it is used for charset detection, as described in the XML
specs.  But I'm not familiar enough with HaXml to determine if this is
due to how it is being used by hpodder or by design.

Signed-off-by: Kevin Locke kevin@kevinlocke.name
