### PR TITLE
Don't use ~/.curlrc options

### DIFF
--- a/Download.hs
+++ b/Download.hs
@@ -87,7 +87,7 @@ startGetURL :: String           -- ^ URL to download
 startGetURL url dirbase allowresume =
     do curlrc <- getCurlConfig
        havecurlrc <- doesFileExist curlrc
-       let curlrcopts = (if havecurlrc then ["-K", curlrc] else [])
+       let curlrcopts = (if havecurlrc then ["-K", curlrc] else ["-q"])
                         ++ (if allowresume then ["-C", "-"] else [])
        let fp = dirbase ++ "/" ++ getdlfname url
        startsize <- getsize fp
@@ -99,7 +99,7 @@ startGetURL url dirbase allowresume =
                 (defaultFileFlags {trunc = True})
        msgfd2 <- dup msgfd
        pid <- pOpen3Raw Nothing (Just msgfd) (Just msgfd2) 
-                 curl (curlopts ++ curlrcopts ++ [url, "-o", fp])
+                 curl (curlrcopts ++ curlopts ++ [url, "-o", fp])
                  (return ())
        closeFd msgfd
        closeFd msgfd2


### PR DESCRIPTION
In the case that ~/.hpodder/curlrc does not exist, the -K option is not
passed to curl and curl will read the user's ~/.curlrc for options.
This can cause difficult to diagnose problems when ~/.curlrc includes
options which hpodder does not expect.

This is a backwards-incompatible change for users with ~/.curlrc and
without ~/.hpodder/curlrc which contains options not overridden by the
curl invocation from hpodder.  I contend that this is less painful than
continuing to support this behavior going forwards, both because it is
undocumented and because it can cause rather inscrutable problems for
unsuspecting users.

Note:  This patch changes the order of curlrcopts and curlopts, because
-q must be the first option.  None of the other options used are
position-sensitive.

Signed-off-by: Kevin Locke kevin@kevinlocke.name
