### PR TITLE
Support compressed content encodings

### DIFF
--- a/Download.hs
+++ b/Download.hs
@@ -65,6 +65,7 @@ curlopts = ["-A", "hpodder v1.0.0; Haskell; GHC", -- Set User-Agent
             "-L",               -- Follow redirects
             "-y", "60", "-Y", "1", -- Timeouts
             "--retry", "2",     -- Retry twice
+            "--compressed",     -- Support compressed content encodings
             "--globoff",        -- Disable globbing on URLs (#79)
             "-f"                -- Fail on server errors
            ]


### PR DESCRIPTION
Curl supports several HTTP content encodings (such as deflate and gzip)
for compressing responses.  Pass the --compressed option to enable
advertising support to servers via the Accept-Encoding HTTP header.

This won't have much of an effect for compressed audio if servers choose
to compress it, but for the XML it is significant.

Signed-off-by: Kevin Locke kevin@kevinlocke.name
